### PR TITLE
altium-symbols repo - initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.slm
+.vscode
+.DS_Store
+designs
+parts-db
+

--- a/examples/board.stanza
+++ b/examples/board.stanza
@@ -37,15 +37,15 @@ pcb-material soldermask :
 
 public pcb-stackup jlcpcb-jlc2313 :
   name = "JLCPCB 4-layer 1.6mm"
-  layer(0.019, soldermask) ; 0.5mil over conductor
-  layer(0.035, copper)
-  layer(0.1, prepreg-2313)
-  layer(0.0175, copper)
-  layer(1.2650, core)
-  layer(0.0175, copper)
-  layer(0.1, prepreg-2313)
-  layer(0.035, copper)
-  layer(0.019, soldermask) ; 0.5mil over conductor
+  stack(0.019, soldermask) ; 0.5mil over conductor
+  stack(0.035, copper)
+  stack(0.1, prepreg-2313)
+  stack(0.0175, copper)
+  stack(1.2650, core)
+  stack(0.0175, copper)
+  stack(0.1, prepreg-2313)
+  stack(0.035, copper)
+  stack(0.019, soldermask) ; 0.5mil over conductor
 
 
 public pcb-board default-board (outline:Shape) :

--- a/examples/board.stanza
+++ b/examples/board.stanza
@@ -1,0 +1,75 @@
+#use-added-syntax(jitx)
+doc:\<DOC>
+  Default board settings to be usedd by the examples.
+<DOC>
+defpackage altium-symbols/examples/board:
+  import core
+  import jitx
+
+pcb-material copper :
+  type = Conductor
+  name = "Copper"
+
+pcb-material core :
+  type = Dielectric
+  dielectric-coefficient = 4.26
+  name = "FR4 Core"
+
+pcb-material core-45 :
+  type = Dielectric
+  dielectric-coefficient = 4.5
+  name = "4.5 DK FR4 Core"
+
+pcb-material prepreg :
+  type = Dielectric
+  dielectric-coefficient = 4.26
+  name = "FR4 Prepreg 2113/2116"
+
+pcb-material prepreg-2313 :
+  type = Dielectric
+  dielectric-coefficient = 4.05
+  name = "FR4 Prepreg 2313"
+
+pcb-material soldermask :
+  type = Dielectric
+  dielectric-coefficient = 3.9
+  name = "Taiyo BSN4000"
+
+public pcb-stackup jlcpcb-jlc2313 :
+  name = "JLCPCB 4-layer 1.6mm"
+  layer(0.019, soldermask) ; 0.5mil over conductor
+  layer(0.035, copper)
+  layer(0.1, prepreg-2313)
+  layer(0.0175, copper)
+  layer(1.2650, core)
+  layer(0.0175, copper)
+  layer(0.1, prepreg-2313)
+  layer(0.035, copper)
+  layer(0.019, soldermask) ; 0.5mil over conductor
+
+
+public pcb-board default-board (outline:Shape) :
+  stackup = jlcpcb-jlc2313
+  boundary = outline
+  signal-boundary = outline
+
+public pcb-rules default-rules :
+  min-copper-width = 0.13 ; 5mil
+  min-copper-copper-space = 0.2 ;
+  min-copper-hole-space = 0.2032 ; 8mil
+  min-copper-edge-space = 0.381 ; 10mil outer, but 15mil inner
+  min-annular-ring = 0.1524 ; 6mil
+  min-drill-diameter = 0.254 ; 10mil
+  min-silkscreen-width = 0.2 ; 3mil
+  min-pitch-leaded = 0.35 ; guess
+  min-pitch-bga = 0.35 ; guess
+  max-board-width = 457.2 ; 18in
+  max-board-height = 609.6 ; 24in
+  solder-mask-registration = 0.15
+  min-silk-solder-mask-space = 0.15
+  min-silkscreen-text-height = 0.762
+  min-th-pad-expand-outer = 0.15
+  min-soldermask-opening = 0.152
+  min-soldermask-bridge = 0.102
+  min-hole-to-hole = 0.254
+  min-pth-pin-solder-clearance = 3.0

--- a/examples/components/comp-capacitor.stanza
+++ b/examples/components/comp-capacitor.stanza
@@ -1,0 +1,64 @@
+#use-added-syntax(jitx)
+defpackage altium-symbols/examples/components/comp-capacitor :
+  import core
+  import jitx
+  import jitx/commands
+
+
+pcb-pad rect-smd-pad :
+  name = "rect-smd-pad"
+  type = SMD
+  shape = Rectangle(0.600, 0.280)
+  layer(Paste(Top)) = Rectangle(0.600, 0.280)
+  layer(SolderMask(Top)) = Rectangle(0.700, 0.380)
+
+pcb-landpattern lp :
+  pad p[1] : rect-smd-pad at loc(0.0, 0.410) on Top
+  pad p[2] : rect-smd-pad at loc(0.0, -0.410) on Top
+
+  layer(Silkscreen("F-SilkS", Top)) = Text(">REF", 0.6, C, loc(0.750, 0.0, 270.000))
+  layer(CustomLayer("Fab", Top)) = Text(">VALUE", 0.3, C, loc(0.600, 0.0, 270.000))
+  layer(Courtyard(Top)) = Rectangle(0.900, 1.400)
+
+pcb-symbol sym-capacitor-sym :
+  pin p[1] at Point(0.0, 2.540) with :
+    direction = Up
+    length = 0.0
+    number-size = 0.0
+    name-size = 0.0
+  pin p[2] at Point(0.0, -2.540) with :
+    direction = Down
+    length = 0.0
+    number-size = 0.0
+    name-size = 0.0
+
+  draw("value") = Text(">VALUE", 1.27, W, loc(1.270, -1.270))
+  draw("reference") = Text(">REF", 1.27, W, loc(1.270, 1.270))
+  draw("foreground") = Line(0.254, [Point(0.0, 2.540), Point(0.0, 0.508)])
+  draw("foreground") = Line(0.254, [Point(-1.270, 0.508), Point(1.270, 0.508)])
+  draw("foreground") = Line(0.254, [Point(0.0, -0.508), Point(0.0, -2.540)])
+  draw("foreground") = Line(0.254, [Point(-1.270, -0.508), Point(1.270, -0.508)])
+
+public pcb-component component :
+  name = "my-capacitor"
+  description = "Capacitor SMD 10V 10uF X5R ±20% 0402"
+  emodel = Capacitor(1.0e-05, 0.2, 10.0, false, UNKNOWN, "X5R")
+  reference-prefix = "C"
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | electrical-type:String | bank:Int]
+    [p[1] | p[1] | Up | "passive" | 0]
+    [p[2] | p[2] | Down | "passive" | 0]
+
+  assign-landpattern(lp)
+  assign-symbol(sym-capacitor-sym)
+
+  property(self.category) = "capacitor"
+  property(self.case) = "0402"
+  property(self.mounting) = "smd"
+  property(self.rated-temperature) = Toleranced(15.0, 70.0, 70.0)
+  property(self.capacitance) = 1.0e-05
+  property(self.type) = "ceramic"
+  property(self.rated-voltage) = 10.000
+  property(self.temperature-coefficent) = "X5R"
+  property(self.tolerance) = Toleranced(1.0e-05, 2.0e-06, 2.0e-06)
+

--- a/examples/components/comp-resistor.stanza
+++ b/examples/components/comp-resistor.stanza
@@ -1,0 +1,68 @@
+#use-added-syntax(jitx)
+defpackage altium-symbols/examples/components/comp-resistor :
+  import core
+  import jitx
+  import jitx/commands
+
+
+pcb-pad rect-smd-pad :
+  name = "rect-smd-pad"
+  type = SMD
+  shape = Rectangle(0.600, 0.280)
+  layer(Paste(Top)) = Rectangle(0.600, 0.280)
+  layer(SolderMask(Top)) = Rectangle(0.700, 0.380)
+
+pcb-landpattern lp :
+  pad p[1] : rect-smd-pad at loc(0.0, 0.410) on Top
+  pad p[2] : rect-smd-pad at loc(0.0, -0.410) on Top
+
+  layer(Silkscreen("F-SilkS", Top)) = Text(">REF", 0.6, C, loc(0.750, 0.0, 270.000))
+  layer(CustomLayer("Fab", Top)) = Text(">VALUE", 0.3, C, loc(0.600, 0.0, 270.000))
+  layer(Courtyard(Top)) = Rectangle(0.900, 1.400)
+
+pcb-symbol sym-resistor-sym :
+  pin p[1] at Point(0.0, 2.540) with :
+    direction = Up
+    length = 0.0
+    number-size = 0.0
+    name-size = 0.0
+  pin p[2] at Point(0.0, -2.540) with :
+    direction = Down
+    length = 0.0
+    number-size = 0.0
+    name-size = 0.0
+
+  draw("value") = Text(">VALUE", 1.27, W, loc(1.270, -1.270))
+  draw("reference") = Text(">REF", 1.27, W, loc(1.270, 1.270))
+  draw("foreground") = Line(0.254, [Point(0.0, -2.540), Point(0.0, -1.587)])
+  draw("foreground") = Polyline(0.254, [
+    Point(0.0, -1.587)
+    Point(-0.762, -1.270)
+    Point(0.762, -0.635)
+    Point(-0.762, 0.0)
+    Point(0.762, 0.635)
+    Point(-0.762, 1.270)
+    Point(0.0, 1.587)])
+  draw("foreground") = Line(0.254, [Point(0.0, 1.587), Point(0.0, 2.540)])
+
+public pcb-component component :
+  name = "my-resistor"
+  description = "Resistor SMD 10K OHM 5% 1/16W 0402"
+  emodel = Resistor(10000.0, 0.05, 0.063)
+  reference-prefix = "R"
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | electrical-type:String | bank:Int]
+    [p[1] | p[1] | Up | "passive" | 0]
+    [p[2] | p[2] | Down | "passive" | 0]
+
+  assign-landpattern(lp)
+  assign-symbol(sym-resistor-sym)
+
+  property(self.category) = "resistor"
+  property(self.case) = "0402"
+  property(self.mounting) = "smd"
+  property(self.rated-temperature) = Toleranced(50.0, 105.0, 105.0)
+  property(self.rated-power) = 0.063
+  property(self.resistance) = 10000.000
+  property(self.tolerance) = Toleranced(10000.0, 500.0, 500.0)
+

--- a/examples/simple.stanza
+++ b/examples/simple.stanza
@@ -3,24 +3,29 @@ defpackage altium-symbols/examples/simple :
   import core
   import jitx
   import jitx/commands
-  import ocdb/utils/generic-components
   import altium-symbols
   import altium-symbols/examples/board
+  import altium-symbols/examples/components/comp-resistor
+  import altium-symbols/examples/components/comp-capacitor
 
 ; Module to run as a design
 pcb-module top-level :
-  pin GND
-  pin VDD
-  pin signal
+  port GND
+  port VDD
+  port signal
 
-  ; Create a 10k resistor component
-  res-strap(signal, VDD, 10.0e3)
-  cap-strap(signal, GND, 10.0e3)
+  ; Instantiate components
+  inst R1 : altium-symbols/examples/components/comp-resistor/component
+  inst C1 : altium-symbols/examples/components/comp-capacitor/component
+  
+  ; Connect components
+  net (R1.p[1], signal)
+  net net-VDD (R1.p[2], VDD)
+  net (C1.p[1], signal)
+  net net-GND (C1.p[2], GND)
 
-  net net-GND (GND)
+  ; Specify Power/Ground Symbols
   symbol(net-GND) = altium-power-gnd-earth-sym
-
-  net net-VDD (VDD)
   symbol(net-VDD) = altium-power-wave-sym
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
@@ -29,7 +34,6 @@ val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
 set-current-design("simple")
 set-rules(default-rules)
 set-board(default-board(board-shape))
-
 set-main-module(top-level)
 
 ; View the results

--- a/examples/simple.stanza
+++ b/examples/simple.stanza
@@ -5,7 +5,7 @@ defpackage altium-symbols/examples/simple :
   import jitx/commands
   import ocdb/utils/generic-components
   import altium-symbols
-  import jsl/examples/landpatterns/board
+  import altium-symbols/examples/board
 
 ; Module to run as a design
 pcb-module top-level :

--- a/examples/simple.stanza
+++ b/examples/simple.stanza
@@ -1,0 +1,42 @@
+#use-added-syntax(jitx)
+defpackage altium-symbols/examples/simple :
+  import core
+  import jitx
+  import jitx/commands
+  import ocdb/utils/generic-components
+  import altium-symbols
+  import jsl/examples/landpatterns/board
+
+; Module to run as a design
+pcb-module top-level :
+  pin GND
+  pin VDD
+  pin signal
+
+  ; Create a 10k resistor component
+  res-strap(signal, VDD, 10.0e3)
+  cap-strap(signal, GND, 10.0e3)
+
+  net net-GND (GND)
+  symbol(net-GND) = altium-power-gnd-earth-sym
+
+  net net-VDD (VDD)
+  symbol(net-VDD) = altium-power-wave-sym
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("simple")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(top-level)
+
+; View the results
+view-board()
+
+set-export-backend(`kicad)
+view-schematic()
+export-cad()
+
+

--- a/examples/simple.stanza
+++ b/examples/simple.stanza
@@ -38,9 +38,7 @@ set-main-module(top-level)
 
 ; View the results
 view-board()
-
-set-export-backend(`kicad)
 view-schematic()
-export-cad()
+
 
 

--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "altium-symbols"
 version = "0.1.0"
 [dependencies]
-jsl = { git = "JITx-Inc/jsl", version = "0.3.2" }
+
 

--- a/slm.toml
+++ b/slm.toml
@@ -1,0 +1,5 @@
+name = "altium-symbols"
+version = "0.1.0"
+[dependencies]
+jsl = { git = "JITx-Inc/jsl", version = "0.3.2" }
+

--- a/src/altium-symbols.stanza
+++ b/src/altium-symbols.stanza
@@ -1,0 +1,205 @@
+#use-added-syntax(jitx)
+doc:\<DOC>
+   Altium Power and Ground Symbols
+
+   The drawings are placed on the "symbol" layer.
+   The ">Value" text is placed on the "value" layer.
+<DOC>
+defpackage altium-symbols :
+  import core
+  import collections
+  import jitx
+  import math
+  import altium-symbols/utils
+
+doc:\<DOC>Copy of TPowerObjectStyle from Altium Designer API <DOC>
+public defenum TPowerObjectStyle :
+  ePowerCircle
+  ePowerArrow
+  ePowerBar
+  ePowerWave
+  ePowerGndPower
+  ePowerGndSignal
+  ePowerGndEarth
+  eGOSTPowerArrow
+  eGOSTPowerGndPower
+  eGOSTPowerGndEarth
+  eGOSTPowerBar
+
+public defstruct AltiumPowerSymbol :
+  style-enum:TPowerObjectStyle
+  doc:\<DOC>Style name in Altium Designer GUI<DOC>
+  style-name:String
+  doc:\<DOC>The `pcb-symbol` object<DOC>
+  symbol-def:JITXDef
+  doc:\<DOC>The `name` field of the `pcb-symbol`<DOC>
+  symbol-name:String
+
+deftype PowerObject 
+
+public defn power-object (name:TPowerObjectStyle|String) -> JITXDef :
+  val power-symbols = [
+    AltiumPowerSymbol(ePowerCircle, "Circle", altium-power-circle-sym, "ALTIUM-POWER-CIRCLE")
+    AltiumPowerSymbol(ePowerArrow, "Arrow", altium-power-arrow-sym, "ALTIUM-POWER-ARROW")
+    AltiumPowerSymbol(ePowerBar, "Bar", altium-power-bar-sym, "ALTIUM-POWER-BAR")
+    AltiumPowerSymbol(ePowerWave, "Wave", altium-power-wave-sym, "ALTIUM-POWER-WAVE")
+    AltiumPowerSymbol(ePowerGndPower, "Power Ground", altium-power-gnd-power-sym, "ALTIUM-POWER-GND-POWER")
+    AltiumPowerSymbol(ePowerGndSignal, "Power Signal", altium-power-gnd-signal-sym, "ALTIUM-POWER-GND-SIGNAL")
+    AltiumPowerSymbol(ePowerGndEarth, "Earth", altium-power-gnd-earth-sym, "ALTIUM-POWER-GND-EARTH")
+    AltiumPowerSymbol(eGOSTPowerArrow, "GOST Arrow", altium-gost-power-arrow-sym, "ALTIUM-GOST-POWER-ARROW")
+    AltiumPowerSymbol(eGOSTPowerGndPower, "GOST Power", altium-gost-gnd-power-sym, "ALTIUM-GOST-GND-POWER")
+    AltiumPowerSymbol(eGOSTPowerGndEarth, "GOST Earth", altium-gost-gnd-earth-sym, "ALTIUM-GOST-GND-EARTH")
+    AltiumPowerSymbol(eGOSTPowerBar, "GOST Bar",altium-gost-bar-sym, "ALTIUM-GOST-BAR")
+  ]
+  match(name) :
+    (enum:TPowerObjectStyle) :
+      match(find({style-enum(_) == enum} power-symbols)):
+        (sym:AltiumPowerSymbol): symbol-def(sym) 
+        (f:False) :
+          throw(Exception("Unrecognized Altium Power Object Style %_" % [enum]))
+    (name:String) : 
+      match(find({style-name(_) == name} power-symbols)):
+        (sym:AltiumPowerSymbol): symbol-def(sym) 
+        (f:False) :
+          throw(Exception("Unrecognized Altium Power Object Style Name %_" % [name]))
+
+public defn altium-power-symbol (style:Int) -> String:
+  altium-power-symbols[style] where:
+    ; The order corresponds to enum SCH.TPowerObjectStyle in Altium API
+    val altium-power-symbols =
+      [ "altium-power-circle-sym"       ; 0 - ePowerCircle
+        "altium-power-arrow-sym"        ; 1 - ePowerArrow
+        "altium-power-bar-sym"          ; 2 - ePowerBar
+        "altium-power-wave-sym"         ; 3 - ePowerWave
+        "altium-power-gnd-power-sym"    ; 4 - ePowerGndPower
+        "altium-power-gnd-signal-sym"   ; 5 - ePowerGndSignal
+        "altium-power-gnd-earth-sym"    ; 6 - ePowerGndEarth
+        "altium-gost-power-arrow-sym"   ; 7 - eGOSTPowerArrow
+        "altium-gost-gnd-power-sym"     ; 8 - eGOSTPowerGndPower
+        "altium-gost-gnd-earth-sym"     ; 9 - eGOSTPowerGndEarth
+        "altium-gost-bar-sym"           ; 10 - altium-gost-bar-sym
+      ]
+
+public pcb-symbol altium-power-circle-sym :
+  name = "ALTIUM-POWER-CIRCLE"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-circle([3.0 / 2.0 * 0.5, 0.0], 0.5 / 2.0)
+  unit-line([[0.0, 0.0], [0.5, 0.0]])
+  unit-val([1.0, -0.2])
+  
+  preferred-orientation = PreferRotation([1])
+
+public pcb-symbol altium-power-arrow-sym :
+  name = "ALTIUM-POWER-ARROW"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [0.3, 0.0]])
+  unit-triangle([0.3, 0.0], [0.9, 0.0], 0.6)
+  unit-val([1.0, -0.2])
+
+  preferred-orientation = PreferRotation([1])
+
+public pcb-symbol altium-power-bar-sym : 
+  name = "ALTIUM-POWER-BAR"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, 0.5], [1.0, -0.5]])
+  unit-val([0.2, 0.2])
+
+  preferred-orientation = PreferRotation([1])
+
+public pcb-symbol altium-power-wave-sym :
+  name = "ALTIUM-POWER-WAVE"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [0.6, 0.0]])
+  unit-approx-arc([1.0, 0.0], 0.4, PI, 3.0 * PI / 2.0)
+  unit-approx-arc([0.2, 0.0], 0.4, PI / 2.0)
+
+  preferred-orientation = PreferRotation([1])
+
+public pcb-symbol altium-power-gnd-power-sym :
+  name = "ALTIUM-POWER-GND-POWER"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, -1.0], [1.0, 1.0]], 0.1)
+  unit-line([[1.28, -0.72], [1.28, 0.72]], 0.1)
+  unit-line([[1.56, -0.44], [1.56, 0.44]], 0.1)
+  unit-line([[1.84, -0.16], [1.84, 0.16]], 0.1)
+  unit-val([1.0, -0.4])
+
+  preferred-orientation = PreferRotation([3])
+
+public pcb-symbol altium-power-gnd-signal-sym :
+  name = "ALTIUM-POWER-GND-SIGNAL"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-triangle([1.0, 0.0], [2.0, 0.0], 2.0)
+  unit-val([1.0, -0.4])
+
+  preferred-orientation = PreferRotation([3])
+
+public pcb-symbol altium-power-gnd-earth-sym :
+  name = "ALTIUM-POWER-GND-EARTH"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, -1.0], [1.0, 1.0]])
+  unit-line([[1.0, -1.0], [2.0, -1.5]])
+  unit-line([[1.0, 0.0], [2.0, -0.5]])
+  unit-line([[1.0, 1.0], [2.0, 0.5]])
+
+  unit-val([0.2, -0.2])
+
+  preferred-orientation = PreferRotation([3])
+
+public pcb-symbol altium-gost-power-arrow-sym :
+  name = "ALTIUM-GOST-POWER-ARROW"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, 0.0], [0.4, 0.3]])
+  unit-line([[1.0, 0.0], [0.4, -0.3]])
+  unit-val([0.6, 0.2])
+
+  preferred-orientation = PreferRotation([1])
+
+public pcb-symbol altium-gost-gnd-power-sym :
+  name = "ALTIUM-GOST-GND-POWER"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [1.5, 0.0]])
+  unit-line([[1.5, -1.0], [1.5, 1.0]], 0.1)
+  unit-line([[1.9, -0.6], [1.9, 0.6]], 0.1)
+  unit-line([[2.3, -0.2], [2.3, 0.2]], 0.1)
+  unit-val([0.2, -0.2])
+
+  preferred-orientation = PreferRotation([3])
+
+public pcb-symbol altium-gost-gnd-earth-sym :
+  name = "ALTIUM-GOST-GND-EARTH"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-circle([1.5, 0.0], 1.25)
+  unit-line([[0.0, 0.0], [1.5, 0.0]])
+  unit-line([[1.5, -1.0], [1.5, 1.0]], 0.1)
+  unit-line([[1.9, -0.6], [1.9, 0.6]], 0.1)
+  unit-line([[2.3, -0.2], [2.3, 0.2]], 0.1)
+  unit-val([0.72, -0.2])
+
+  preferred-orientation = PreferRotation([3])
+
+public pcb-symbol altium-gost-bar-sym : 
+  name = "ALTIUM-GOST-BAR"
+  pin p[0] at unit-point(0.0, 0.0)
+
+  unit-line([[0.0, 0.0], [2.0, 0.0]])
+  unit-line([[2.0, -0.8], [2.0, 0.8]])
+  unit-val([1.0, -0.2])
+
+  preferred-orientation = PreferRotation([1])
+

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -1,0 +1,101 @@
+#use-added-syntax(jitx)
+defpackage altium-symbols/utils :
+  import core
+  import collections
+  import math
+  import jitx
+
+; ====== Unit Conversion Functions =======
+; The following functions expect sizes and coordinates in "Symbol Units" which 
+; is the expected grid size in schematics. For Kicad this is 50 mil, or 1.27 mm
+
+val UNIT-TO-MM = 2.54
+
+public defn unit-point (x:Double, y:Double, scale:Double = UNIT-TO-MM) :
+  Point(scale * x, scale * y)
+  
+public defn point-coords (p:Point|[Double, Double]) :
+  match(p) :
+    (pp:Point) : [x(pp), y(pp)]
+    (dd:[Double, Double]) : dd
+  
+public defn unit-point (p:Point|[Double, Double], scale:Double) :
+  val [x, y] = point-coords(p)
+  unit-point(x, y, scale)
+
+public defn unit-point (p:Point|[Double, Double]) :
+  unit-point(p, UNIT-TO-MM)
+
+public defn unit-points (ps:Collection<Point|[Double, Double]>,
+                         scale:Double = UNIT-TO-MM) :
+  to-list(seq({unit-point(_, scale)}, ps))
+
+public defn unit-loc (p:Point|[Double, Double], scale:Double = UNIT-TO-MM) :
+  val [x, y] = point-coords(p)
+  val l = loc(x, y, 0.0, NoFlip)
+  sub-center(l, unit-point(center(l), scale))
+
+public defn unit-line (ps:Collection<Point|[Double, Double]>,
+                       w:Double = 0.05,
+                       scale:Double = UNIT-TO-MM) :
+  inside pcb-symbol :
+    draw("symbol") = Line(scale * w, unit-points(ps, scale))
+
+public defn unit-polygon (ps:Collection<Point|[Double, Double]>,
+                          scale:Double = UNIT-TO-MM) :
+  inside pcb-symbol :
+    draw("symbol") = Polygon(unit-points(ps, scale))
+
+public defn unit-circle (p:Point|[Double, Double],
+                         r:Double,
+                         scale:Double = UNIT-TO-MM) :
+  val [x, y] = point-coords(p)
+  inside pcb-symbol :
+    draw("symbol") = Circle(scale * x, scale * y, scale * r)
+
+public defn unit-triangle (p0:Point|[Double, Double],
+                           p1:Point|[Double, Double],
+                           w:Double,
+                           scale:Double = UNIT-TO-MM) :
+  val [x0, y0] = point-coords(p0)
+  val [x1, y1] = point-coords(p1)
+
+  val [dx, dy] = [x1 - x0, y1 - y0]
+  val len = pow(pow(dx, 2.0) + pow(dy, 2.0), 0.5)
+  val [ux, uy] = [dx / len, dy / len]
+
+  val w2 = w / 2.0
+  val p2 = [x0 - (w2 * uy), y0 + (w2 * ux)]
+  val p3 = [x0 + (w2 * uy), y0 - (w2 * ux)]
+  
+  unit-polygon([p1, p2, p3], scale)
+
+public defn unit-val (p:Point|[Double, Double],
+                       txt = ">VALUE",
+                       size:Double = 0.5,
+                       a:Anchor = W,
+                       scale:Double = UNIT-TO-MM) :
+  inside pcb-symbol :
+    ;val pt-size = to-int(ceil(size * scale * MM-TO-POINT)) [TODO: Fix this]
+    val pt-size = 0.7056 ;[Placeholder]
+    draw("value") = Text(to-string(txt), pt-size, a, unit-loc(p, scale))
+
+public defn unit-approx-arc (p:Point|[Double, Double], 
+                             r:Double,
+                             a1:Double,
+                             a0:Double = 0.0,
+                             w:Double = 0.05,
+                             n:Int = 10,
+                             scale:Double = UNIT-TO-MM) :
+  val pts = Vector<[Double, Double]>()
+  val a-delta = (a1 - a0) / to-double(n)
+  val [x, y] = point-coords(p)
+
+  for i in 0 through n do :
+    val ai = a0 + to-double(i) * a-delta
+    add(pts, [x + r * cos(ai), y + r * sin(ai)])
+
+  unit-line(pts, w, scale)
+
+
+

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,4 +1,7 @@
+include? ".slm/stanza.proj"  ; Dependencies
+pkg-cache: ".slm/pkg-cache"
 
+package altium-symbols defined-in "./src/altium-symbols.stanza"
 packages altium-symbols/* defined-in "./src/"
 packages altium-symbols/examples/* defined-in "./examples/"
 

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,0 +1,4 @@
+
+packages altium-symbols/* defined-in "./src/"
+packages altium-symbols/examples/* defined-in "./examples/"
+


### PR DESCRIPTION
The initial version of the altium-symbols repo.

- Copied `pcb-symbol`'s for Altium Power/Ground symbols from OCDB
- Include only the functions from `ocdb/utils` that are used to create the Altium symbols. Simplify the interface with default values for arguments)
- Added a simple example. 

I did not use the Symbol Net framework yet.
This version just copied the pct-symbol's from OCDB with no change, except:
- put all drawings on the "symbol" layer <= Current OCDB code would have some drawings placed in the "symbol" layer and some are the "foreground" layer.
- put the value text on the "value" layer <= same as the current OCDB