### PR TITLE
Fix Net Labels on Altium Symbols

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "altium-symbols"
-version = "0.1.0"
+version = "0.2.0"
 [dependencies]
 
 

--- a/src/altium-symbols.stanza
+++ b/src/altium-symbols.stanza
@@ -86,8 +86,8 @@ public pcb-symbol altium-power-circle-sym :
 
   unit-circle([3.0 / 2.0 * 0.5, 0.0], 0.5 / 2.0)
   unit-line([[0.0, 0.0], [0.5, 0.0]])
-  unit-val([1.0, -0.2])
-  
+  unit-val([0.0, -1.7], a = S, pose = loc(0.0, 0.0, 90.0), size = 0.5)
+
   preferred-orientation = PreferRotation([1])
 
 public pcb-symbol altium-power-arrow-sym :
@@ -96,7 +96,7 @@ public pcb-symbol altium-power-arrow-sym :
 
   unit-line([[0.0, 0.0], [0.3, 0.0]])
   unit-triangle([0.3, 0.0], [0.9, 0.0], 0.6)
-  unit-val([1.0, -0.2])
+  unit-val([0.0, -1.6], a = S, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([1])
 
@@ -106,7 +106,7 @@ public pcb-symbol altium-power-bar-sym :
 
   unit-line([[0.0, 0.0], [1.0, 0.0]])
   unit-line([[1.0, 0.5], [1.0, -0.5]])
-  unit-val([0.2, 0.2])
+  unit-val([0.0, -1.7], a = S, pose = loc(0.0, 0.0, 90.0) , size = 0.5)
 
   preferred-orientation = PreferRotation([1])
 
@@ -117,6 +117,7 @@ public pcb-symbol altium-power-wave-sym :
   unit-line([[0.0, 0.0], [0.6, 0.0]])
   unit-approx-arc([1.0, 0.0], 0.4, PI, 3.0 * PI / 2.0)
   unit-approx-arc([0.2, 0.0], 0.4, PI / 2.0)
+  unit-val([0.0, -1.7], a = S, pose = loc(0.0, 0.0, 90.0) , size = 0.5)
 
   preferred-orientation = PreferRotation([1])
 
@@ -129,7 +130,7 @@ public pcb-symbol altium-power-gnd-power-sym :
   unit-line([[1.28, -0.72], [1.28, 0.72]], 0.1)
   unit-line([[1.56, -0.44], [1.56, 0.44]], 0.1)
   unit-line([[1.84, -0.16], [1.84, 0.16]], 0.1)
-  unit-val([1.0, -0.4])
+  unit-val([0.0, -2.0], a = N, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([3])
 
@@ -139,7 +140,7 @@ public pcb-symbol altium-power-gnd-signal-sym :
 
   unit-line([[0.0, 0.0], [1.0, 0.0]])
   unit-triangle([1.0, 0.0], [2.0, 0.0], 2.0)
-  unit-val([1.0, -0.4])
+  unit-val([0.0, -2.0], a = N, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([3])
 
@@ -153,7 +154,7 @@ public pcb-symbol altium-power-gnd-earth-sym :
   unit-line([[1.0, 0.0], [2.0, -0.5]])
   unit-line([[1.0, 1.0], [2.0, 0.5]])
 
-  unit-val([0.2, -0.2])
+  unit-val([0.0, -2.0], a = N, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([3])
 
@@ -164,7 +165,8 @@ public pcb-symbol altium-gost-power-arrow-sym :
   unit-line([[0.0, 0.0], [1.0, 0.0]])
   unit-line([[1.0, 0.0], [0.4, 0.3]])
   unit-line([[1.0, 0.0], [0.4, -0.3]])
-  unit-val([0.6, 0.2])
+  unit-val([0.0, -1.7], a = S, pose = loc(0.0, 0.0, 90.0) , size = 0.5)
+
 
   preferred-orientation = PreferRotation([1])
 
@@ -176,7 +178,7 @@ public pcb-symbol altium-gost-gnd-power-sym :
   unit-line([[1.5, -1.0], [1.5, 1.0]], 0.1)
   unit-line([[1.9, -0.6], [1.9, 0.6]], 0.1)
   unit-line([[2.3, -0.2], [2.3, 0.2]], 0.1)
-  unit-val([0.2, -0.2])
+  unit-val([0.0, -2.5], a = N, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([3])
 
@@ -189,7 +191,7 @@ public pcb-symbol altium-gost-gnd-earth-sym :
   unit-line([[1.5, -1.0], [1.5, 1.0]], 0.1)
   unit-line([[1.9, -0.6], [1.9, 0.6]], 0.1)
   unit-line([[2.3, -0.2], [2.3, 0.2]], 0.1)
-  unit-val([0.72, -0.2])
+  unit-val([0.0, -3.0], a = N, pose = loc(0.0, 0.0, 90.0), size = 0.5)
 
   preferred-orientation = PreferRotation([3])
 
@@ -199,7 +201,8 @@ public pcb-symbol altium-gost-bar-sym :
 
   unit-line([[0.0, 0.0], [2.0, 0.0]])
   unit-line([[2.0, -0.8], [2.0, 0.8]])
-  unit-val([1.0, -0.2])
+  unit-val([0.0, -2.7], a = S, pose = loc(0.0, 0.0, 90.0) , size = 0.5)
+
 
   preferred-orientation = PreferRotation([1])
 

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -71,14 +71,16 @@ public defn unit-triangle (p0:Point|[Double, Double],
   unit-polygon([p1, p2, p3], scale)
 
 public defn unit-val (p:Point|[Double, Double],
+                      --
                        txt = ">VALUE",
-                       size:Double = 0.5,
+                       size:Double = 0.27,
                        a:Anchor = W,
-                       scale:Double = UNIT-TO-MM) :
+                       scale:Double = UNIT-TO-MM
+                       pose:Pose = loc(0.0, 0.0)) :
   inside pcb-symbol :
     ;val pt-size = to-int(ceil(size * scale * MM-TO-POINT)) [TODO: Fix this]
-    val pt-size = 0.7056 ;[Placeholder]
-    draw("value") = Text(to-string(txt), pt-size, a, unit-loc(p, scale))
+    val pt-size = size * scale
+    draw("value") = pose * Text(to-string(txt), pt-size, a, unit-loc(p, scale))
 
 public defn unit-approx-arc (p:Point|[Double, Double], 
                              r:Double,


### PR DESCRIPTION
Here is what they looked like before: 
<img width="1075" alt="Screenshot 2025-03-18 at 12 49 30 PM" src="https://github.com/user-attachments/assets/eafbfffe-9913-496a-a6cb-751ff919386c" />

Here is the updated versions: 

<img width="1069" alt="Screenshot 2025-03-18 at 12 47 21 PM" src="https://github.com/user-attachments/assets/60b5d968-fa9f-41c1-8837-3f16be4544f2" />

These are more representative of what we see in Altium.

Bumps to version 0.2.0